### PR TITLE
Batch 1: Migrate Neon Splash + Pop Art Burst to shared StyleGallery (no visual change)

### DIFF
--- a/FOUNDER_WORKFLOW.md
+++ b/FOUNDER_WORKFLOW.md
@@ -1,0 +1,113 @@
+e# Founder’s Workflow (Visual, No-Terminal Guide)
+
+This is your simple, repeatable process to manage Wondertone inside VS Code using buttons and panels (no complex commands).
+
+---
+
+## What each tool is
+- VS Code: Your workshop (edit files, see changes, commit, push).
+- GitHub: Your cloud backup (stores branches and commits; where PRs live).
+- Vercel: Your live host (auto-deploys when you push to the configured branch, usually “main”).
+
+---
+
+## Daily quick-start checklist
+1) Open the repo in VS Code
+- File → Open Folder… → select the project folder.
+
+2) Create a safe workspace (new branch)
+- Bottom-left status bar: click the branch name → “Create new branch…”
+- Name it (example: feat/bundle-trim) → confirm “Switch to new branch”.
+
+3) Make changes and preview differences
+- Before saving: press Cmd+Shift+P → “File: Compare Active File with Saved” for side-by-side before/after.
+- After saving: open Source Control (left sidebar icon) → click a changed file to see a side-by-side diff.
+- Tip: Use the inline diff toggle button on the diff tab if you prefer single-column view.
+
+4) Run the app (without terminal)
+- Explorer panel → “NPM Scripts” → expand:
+  - dev → click the play icon to start the dev server (opens your app in the browser).
+  - build → builds production files.
+  - build:analyze → builds and opens a bundle size treemap (dist/stats.html).
+  - deps:check → scans for unused dependencies (review results in the Output/Terminal panel).
+
+5) Save your work (commit)
+- Source Control panel:
+  - Stage files: click the + next to each file, or the + next to “Changes” to stage all.
+  - Type a short message (e.g., “fix: reduce bundle size by pruning unused Radix deps”).
+  - Click the checkmark (Commit).
+
+6) Back up to GitHub (push/sync)
+- Source Control panel:
+  - First time on a new branch: click “Publish Branch”.
+  - Afterwards: click “Sync Changes” to push new commits.
+
+7) Open a Pull Request (optional, visual)
+- Install “GitHub Pull Requests and Issues” extension:
+  - Click the GitHub icon in the Activity Bar → “Create Pull Request”.
+  - Or open GitHub in the browser and click “Compare & pull request”.
+
+---
+
+## Visual diffs: quick reference
+- Unsaved edits: Cmd+Shift+P → “File: Compare Active File with Saved”.
+- Saved edits: Source Control → click a file under “Changes” to open the diff view.
+- Color key in editor gutter:
+  - Green = added, Blue = modified, Red = removed.
+
+---
+
+## Branching strategy (keep main stable)
+- Create a branch per task:
+  - feat/<thing>, fix/<issue>, chore/<maintenance>, docs/<docs-change>.
+- Commit small, meaningful changes frequently.
+- Merge to main via Pull Requests.
+
+---
+
+## Bundle size workflow (visual)
+- Run “build:analyze” from NPM Scripts.
+- When the treemap opens (dist/stats.html):
+  - Look for large boxes (big libraries).
+  - If a library looks unused, search for its imports in VS Code (Cmd+Shift+F) before removing.
+- After removing a dependency, run “build:analyze” again to confirm the drop.
+
+---
+
+## Dependency cleanup (visual)
+- Run “deps:check” from NPM Scripts.
+- Review the output list of “unused” packages.
+- Before removing, verify usage with VS Code search (Cmd+Shift+F).
+- Remove via package.json (right-click → Open Preview → edit) then Source Control → commit.
+
+---
+
+## Handling merge conflicts (when they happen)
+- VS Code will show conflict markers in files.
+- Use the in-editor buttons:
+  - “Accept Current Change” (your version),
+  - “Accept Incoming Change” (remote version),
+  - or “Accept Both Changes”.
+- Save, then commit to finish.
+
+---
+
+## Roll back safely
+- Source Control → click a file → use “Timeline” to view history and restore a previous version.
+- For whole-commit rollback: Install “GitLens” → open the Repository view → right-click a commit → Revert.
+
+---
+
+## Keeping this guide handy
+- Open this file → right-click the tab → Pin.
+- Optional: Add a link from README.md to this file.
+- Keep this as your first tab daily.
+
+---
+
+## Quick tips
+- Use Problems panel (bottom) for errors/warnings; click an item to jump to the file.
+- Rename branches from the status bar (click branch name → “Rename”).
+- Use Split Editor (Cmd+\) to compare files side-by-side quickly.
+
+You’ve got this—keep each change small, review visually, commit often, push to GitHub, and verify on Vercel when merging to main.

--- a/src/components/abstract-fusion/AbstractFusionGallery.tsx
+++ b/src/components/abstract-fusion/AbstractFusionGallery.tsx
@@ -1,41 +1,36 @@
 
-import { Card, CardContent } from "@/components/ui/card";
+import StyleGallery from "@/components/shared/StyleGallery";
 
 const AbstractFusionGallery = () => {
-  const galleryImages = [
+  const items = [
     {
+      id: "abstract-fusion-1",
       src: "/lovable-uploads/917203b5-e096-43e3-a992-115124cf0e42.png",
-      alt: "Abstract Fusion Portrait Example"
+      alt: "Abstract Fusion Portrait Example",
     },
     {
+      id: "abstract-fusion-2",
       src: "/lovable-uploads/723f2a1a-0e03-4c36-a8d3-a930c81a7d08.png",
-      alt: "Pop Art Style Example"
+      alt: "Pop Art Style Example",
     },
     {
+      id: "abstract-fusion-3",
       src: "/lovable-uploads/60a93ae3-c149-4515-aa89-356396b7ff33.png",
-      alt: "Artistic Mashup Example"
-    }
+      alt: "Artistic Mashup Example",
+    },
   ];
 
   return (
-    <section className="py-16 bg-white">
-      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-        <h2 className="text-3xl font-bold text-center text-gray-900 mb-12">Style Gallery</h2>
-        <div className="grid md:grid-cols-3 gap-8">
-          {galleryImages.map((image, index) => (
-            <Card key={index} className="overflow-hidden">
-              <CardContent className="p-0">
-                <img 
-                  src={image.src}
-                  alt={image.alt}
-                  className="w-full aspect-square object-cover hover:scale-105 transition-transform duration-300"
-                />
-              </CardContent>
-            </Card>
-          ))}
-        </div>
-      </div>
-    </section>
+    <StyleGallery
+      items={items}
+      sectionClassName="py-16 bg-white"
+      containerClassName="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8"
+      titleText="Style Gallery"
+      titleClassName="text-3xl font-bold text-center text-gray-900 mb-12"
+      gridClassName="grid md:grid-cols-3 gap-8"
+      cardClassName="overflow-hidden"
+      imgClassName="w-full aspect-square object-cover hover:scale-105 transition-transform duration-300"
+    />
   );
 };
 

--- a/src/components/electric-bloom/ElectricBloomGallery.tsx
+++ b/src/components/electric-bloom/ElectricBloomGallery.tsx
@@ -1,41 +1,36 @@
 
-import { Card, CardContent } from "@/components/ui/card";
+import StyleGallery from "@/components/shared/StyleGallery";
 
 const ElectricBloomGallery = () => {
-  const galleryImages = [
+  const items = [
     {
+      id: "electric-bloom-1",
       src: "/lovable-uploads/f9e1b137-663e-403f-8117-56679fe2de93.png",
-      alt: "Electric Bloom Portrait Example"
+      alt: "Electric Bloom Portrait Example",
     },
     {
+      id: "electric-bloom-2",
       src: "/lovable-uploads/58ce8c1f-4fcb-4135-a850-600a0915b141.png",
-      alt: "Neon Aura Style Example"
+      alt: "Neon Aura Style Example",
     },
     {
+      id: "electric-bloom-3",
       src: "/lovable-uploads/723f2a1a-0e03-4c36-a8d3-a930c81a7d08.png",
-      alt: "Cyberpunk Glow Example"
-    }
+      alt: "Cyberpunk Glow Example",
+    },
   ];
 
   return (
-    <section className="py-16 bg-slate-900">
-      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-        <h2 className="text-3xl font-bold text-center text-white mb-12">Style Gallery</h2>
-        <div className="grid md:grid-cols-3 gap-8">
-          {galleryImages.map((image, index) => (
-            <Card key={index} className="overflow-hidden bg-slate-800 border-slate-600 hover:border-blue-500/30 transition-colors">
-              <CardContent className="p-0">
-                <img 
-                  src={image.src}
-                  alt={image.alt}
-                  className="w-full aspect-square object-cover hover:scale-105 transition-transform duration-300"
-                />
-              </CardContent>
-            </Card>
-          ))}
-        </div>
-      </div>
-    </section>
+    <StyleGallery
+      items={items}
+      sectionClassName="py-16 bg-slate-900"
+      containerClassName="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8"
+      titleText="Style Gallery"
+      titleClassName="text-3xl font-bold text-center text-white mb-12"
+      gridClassName="grid md:grid-cols-3 gap-8"
+      cardClassName="overflow-hidden bg-slate-800 border-slate-600 hover:border-blue-500/30 transition-colors"
+      imgClassName="w-full aspect-square object-cover hover:scale-105 transition-transform duration-300"
+    />
   );
 };
 

--- a/src/components/neon-splash/NeonSplashGallery.tsx
+++ b/src/components/neon-splash/NeonSplashGallery.tsx
@@ -1,41 +1,36 @@
 
-import { Card, CardContent } from "@/components/ui/card";
+import StyleGallery from "@/components/shared/StyleGallery";
 
 const NeonSplashGallery = () => {
-  const galleryImages = [
+  const items = [
     {
+      id: "neon-splash-1",
       src: "/lovable-uploads/58ce8c1f-4fcb-4135-a850-600a0915b141.png",
-      alt: "Neon Splash Portrait Example"
+      alt: "Neon Splash Portrait Example",
     },
     {
+      id: "neon-splash-2",
       src: "/lovable-uploads/f9e1b137-663e-403f-8117-56679fe2de93.png",
-      alt: "Electric Bloom Style Example"
+      alt: "Electric Bloom Style Example",
     },
     {
+      id: "neon-splash-3",
       src: "/lovable-uploads/723f2a1a-0e03-4c36-a8d3-a930c81a7d08.png",
-      alt: "Pop Art Burst Example"
-    }
+      alt: "Pop Art Burst Example",
+    },
   ];
 
   return (
-    <section className="py-16 bg-black">
-      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-        <h2 className="text-3xl font-bold text-center text-white mb-12">Style Gallery</h2>
-        <div className="grid md:grid-cols-3 gap-8">
-          {galleryImages.map((image, index) => (
-            <Card key={index} className="overflow-hidden bg-gray-900 border-gray-700">
-              <CardContent className="p-0">
-                <img 
-                  src={image.src}
-                  alt={image.alt}
-                  className="w-full aspect-square object-cover hover:scale-105 transition-transform duration-300"
-                />
-              </CardContent>
-            </Card>
-          ))}
-        </div>
-      </div>
-    </section>
+    <StyleGallery
+      items={items}
+      sectionClassName="py-16 bg-black"
+      containerClassName="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8"
+      titleText="Style Gallery"
+      titleClassName="text-3xl font-bold text-center text-white mb-12"
+      gridClassName="grid md:grid-cols-3 gap-8"
+      cardClassName="overflow-hidden bg-gray-900 border-gray-700"
+      imgClassName="w-full aspect-square object-cover hover:scale-105 transition-transform duration-300"
+    />
   );
 };
 

--- a/src/components/pop-art-burst/PopArtBurstGallery.tsx
+++ b/src/components/pop-art-burst/PopArtBurstGallery.tsx
@@ -1,41 +1,36 @@
 
-import { Card, CardContent } from "@/components/ui/card";
+import StyleGallery from "@/components/shared/StyleGallery";
 
 const PopArtBurstGallery = () => {
-  const galleryImages = [
+  const items = [
     {
+      id: "pop-art-burst-1",
       src: "/lovable-uploads/723f2a1a-0e03-4c36-a8d3-a930c81a7d08.png",
-      alt: "Pop Art Burst Portrait Example"
+      alt: "Pop Art Burst Portrait Example",
     },
     {
+      id: "pop-art-burst-2",
       src: "/lovable-uploads/58ce8c1f-4fcb-4135-a850-600a0915b141.png",
-      alt: "Comic Style Portrait Example"
+      alt: "Comic Style Portrait Example",
     },
     {
+      id: "pop-art-burst-3",
       src: "/lovable-uploads/f9e1b137-663e-403f-8117-56679fe2de93.png",
-      alt: "Retro Pop Art Example"
-    }
+      alt: "Retro Pop Art Example",
+    },
   ];
 
   return (
-    <section className="py-16 bg-white">
-      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-        <h2 className="text-3xl font-bold text-center text-gray-900 mb-12">Style Gallery</h2>
-        <div className="grid md:grid-cols-3 gap-8">
-          {galleryImages.map((image, index) => (
-            <Card key={index} className="overflow-hidden bg-white border-2 border-gray-200 hover:border-red-300 transition-colors">
-              <CardContent className="p-0">
-                <img 
-                  src={image.src}
-                  alt={image.alt}
-                  className="w-full aspect-square object-cover hover:scale-105 transition-transform duration-300"
-                />
-              </CardContent>
-            </Card>
-          ))}
-        </div>
-      </div>
-    </section>
+    <StyleGallery
+      items={items}
+      sectionClassName="py-16 bg-white"
+      containerClassName="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8"
+      titleText="Style Gallery"
+      titleClassName="text-3xl font-bold text-center text-gray-900 mb-12"
+      gridClassName="grid md:grid-cols-3 gap-8"
+      cardClassName="overflow-hidden bg-white border-2 border-gray-200 hover:border-red-300 transition-colors"
+      imgClassName="w-full aspect-square object-cover hover:scale-105 transition-transform duration-300"
+    />
   );
 };
 

--- a/src/components/shared/StyleGallery.tsx
+++ b/src/components/shared/StyleGallery.tsx
@@ -1,0 +1,52 @@
+import { Card, CardContent } from "@/components/ui/card";
+
+type GalleryItem = {
+  id: string;
+  src: string;
+  alt: string;
+};
+
+type StyleGalleryProps = {
+  items: GalleryItem[];
+  sectionClassName: string;
+  containerClassName: string;
+  titleText: string;
+  titleClassName: string;
+  gridClassName: string;
+  cardClassName: string;
+  imgClassName: string;
+};
+
+export default function StyleGallery({
+  items,
+  sectionClassName,
+  containerClassName,
+  titleText,
+  titleClassName,
+  gridClassName,
+  cardClassName,
+  imgClassName,
+}: StyleGalleryProps) {
+  return (
+    <section className={sectionClassName}>
+      <div className={containerClassName}>
+        <h2 className={titleClassName}>{titleText}</h2>
+        <div className={gridClassName}>
+          {items.map((item) => (
+            <Card key={item.id} className={cardClassName}>
+              <CardContent className="p-0">
+                <img
+                  src={item.src}
+                  alt={item.alt}
+                  className={imgClassName}
+                  loading="lazy"
+                  decoding="async"
+                />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
Batch 1 of gallery consolidation using the new `StyleGallery` component.

Summary
- Migrate 2 galleries:
  - `neon-splash/NeonSplashGallery.tsx`
  - `pop-art-burst/PopArtBurstGallery.tsx`
- Preserve exact DOM and Tailwind classes
- Stable ids replace index keys
- Perf-only `<img loading="lazy" decoding="async">` via shared component

Visual Parity Checklist
- Section backgrounds, titles, grid layout unchanged
- Cards keep their exact classes:
  - Neon Splash: `overflow-hidden bg-gray-900 border-gray-700`
  - Pop Art Burst: `overflow-hidden bg-white border-2 border-gray-200 hover:border-red-300 transition-colors`
- Images keep: `w-full aspect-square object-cover hover:scale-105 transition-transform duration-300`
- Image order and alt text identical

Testing
- Local `npm run build` succeeded

Notes
- This PR stacks on top of the pilot PR. Please review pilot first.
