### PR TITLE
Pilot: Consolidate marquee animations (no visual change)

### DIFF
--- a/src/components/product/styles/animations/marquee.css
+++ b/src/components/product/styles/animations/marquee.css
@@ -3,29 +3,31 @@
 
 @keyframes marquee-right {
   0% {
-    transform: translateX(0%);
+    transform: translateX(0);
   }
   100% {
-    transform: translateX(-100%);
+    transform: translateX(-50%);
   }
 }
 
 @keyframes marquee-left {
   0% {
-    transform: translateX(-100%);
+    transform: translateX(-50%);
   }
   100% {
-    transform: translateX(0%);
+    transform: translateX(0);
   }
 }
 
 /* Marquee animation classes */
 .animate-marquee-right {
-  animation: marquee-right 30s linear infinite;
+  animation: marquee-right 45s linear infinite;
+  will-change: transform;
 }
 
 .animate-marquee-left {
-  animation: marquee-left 25s linear infinite;
+  animation: marquee-left 40s linear infinite;
+  will-change: transform;
 }
 
 /* Pause animations on hover for accessibility */


### PR DESCRIPTION
Pilot to consolidate duplicate marquee animations while preserving visuals.

Summary
- Align `src/components/product/styles/animations/marquee.css` with canonical definitions already in `src/index.css`
  - `@keyframes marquee-right/left`: use transform distances `-50%` and matching start positions
  - `.animate-marquee-right/left`: durations `45s`/`40s` and `will-change: transform`
- No DOM/class changes. Hover pause preserved.

Why
- Remove drift between duplicated animations (-100% @ 30s vs -50% @ 45s) that risks inconsistent speeds if/when file gets imported
- Keep animations transform-only and GPU-friendly

Acceptance Criteria
- Customer photo marquee scroll speed and loop cadence are unchanged vs current site (±2% cycle time)
- Hover pauses the animation as before
- No CLS regressions in Lighthouse; smooth timeline in Perf tab

Files touched
- `src/components/product/styles/animations/marquee.css` only

Next
- If approved, we can remove/avoid importing redundant animation bundles and standardize shimmer/progress patterns in follow-ups.
