### PR TITLE
chore: add preview latency harness

### DIFF
--- a/READ.MD
+++ b/READ.MD
@@ -1,0 +1,117 @@
+# Generate-Style-Preview: Acceptance Checklists
+
+This page tracks the v2 pilot, measurement plan, cleanup guards, and flip/rollback. Use it as a literal checklist.
+
+## Goals
+- [ ] Reduce p95 latency and compute by removing server-side polling (v2 via webhook)
+- [ ] Preserve request/response shape and codes to avoid client regressions
+- [ ] Add an on/off flag for instant rollback
+- [ ] Clean up dead code to shrink cold-start surface
+
+## Current Layout (Quick Map)
+- Entry: `supabase/functions/generate-style-preview/index.ts` (Deno `serve`, CORS, validation, env, Supabase, Replicate)
+- Prompt fetch: `stylePromptService.ts` (DB: `style_prompts`), fallback string
+- Replicate orchestration: `replicateService.ts` (retry + prompt enhancer + polling service)
+- Polling: `replicate/pollingService.ts` (2s interval, 30 attempts)
+- Errors/retry: `errorHandling.ts` (`executeWithRetry`, backoff = max(retry-after, exponential))
+
+---
+
+## V2 Pilot Parity
+- [ ] Schema parity: inputs match `requestValidator.ts` (`imageUrl`, `style`, `aspectRatio`, `quality` with legacy normalization)
+- [ ] Response shape: success uses `createSuccessResponse` keys (`preview_url`, `requestId`, `duration`, `timestamp`); errors use `createErrorResponse`
+- [ ] HTTP codes: `200` success, `400` invalid, `503` generation_failed, `500` internal (align with `index.ts` success/failure paths)
+- [ ] Prompt parity: use `StylePromptService.getStylePrompt` + same fallback copy; apply `PromptEnhancer` rules from `replicate/config.ts`
+- [ ] Auth keys: read `OPENAI_API_KEY` and `REPLICATE_API_TOKEN`; return configuration error if missing
+- [ ] Logging parity: diagnostic logs include `requestId`, aspect/quality, prompt length; record `duration`
+
+Notes:
+- v2 POST to Replicate should omit `Prefer: "wait"` and include a webhook URL + secret. Keep the same request body fields (`prompt`, `input_images`, `openai_api_key`, `aspect_ratio`, `quality`).
+
+---
+
+## p50/p95 Validation Procedure
+- [ ] Scenarios: measure cold and warm starts separately; run both low-load and burst tests
+- [ ] Sample size: target N=100 per scenario per version (v1 vs v2)
+- [ ] Warm-up: 5–10 warm-up calls before timed runs
+- [ ] Collection (v1, synchronous): parse `.duration` if present; fallback to wall time
+- [ ] Collection (v2): if synchronous, same as v1; if `202` async, measure end-to-end (request→completion) by polling a status endpoint or reading a Supabase row keyed by `requestId`
+- [ ] Stats: compute min/avg/p50/p95/max and error rate
+
+Example commands (set `URL`/`URL_V2` first):
+
+```zsh
+# Warm-up (v1)
+for i in {1..10}; do \
+  node scripts/measure-latency.ts --url "$URL" --body-inline '{"imageUrl":"data:image/png;base64,","style":"Classic Oil Painting","aspectRatio":"1:1","quality":"medium"}' \
+  --count 1 --concurrency 1 --warmup 0 >/dev/null; \
+  done
+
+# Timed run (v1)
+node scripts/measure-latency.ts --url "$URL" \
+  --body-inline '{"imageUrl":"data:image/png;base64,","style":"Classic Oil Painting","aspectRatio":"1:1","quality":"medium"}' \
+  --count 100 --concurrency 5 --out v1_durations.txt
+
+# Timed run (v2)
+node scripts/measure-latency.ts --url "$URL_V2" \
+  --body-inline '{"imageUrl":"data:image/png;base64,","style":"Classic Oil Painting","aspectRatio":"1:1","quality":"medium"}' \
+  --count 100 --concurrency 5 --out v2_durations.txt
+
+# Quick stats dump is printed as JSON by the script (min/avg/p50/p95/max)
+```
+
+If you must compute p50/p95 manually from the raw files:
+
+```zsh
+awk '{print $2}' v1_durations.txt | sort -n | awk 'BEGIN{c=0} {a[c++]=$1} END{p50=a[int(0.50*c)]; p95=a[int(0.95*c)]; printf("p50=%sms p95=%sms\n",p50,p95)}'
+```
+
+---
+
+## Safe-Delete Search/Guards
+Targets (must have zero imports):
+- [ ] `supabase/functions/generate-style-preview/openaiService.ts`
+- [ ] `supabase/functions/generate-style-preview/imageGenerationService.ts`
+- [ ] `supabase/functions/generate-style-preview/canvasWatermarkService.ts`
+- [ ] `supabase/functions/generate-style-preview/stylePrompts.ts`
+- [ ] `supabase/functions/generate-style-preview/types.ts` (function root, not `replicate/types.ts`)
+- [ ] Candidate: `supabase/functions/generate-style-preview/imageUtils.ts` (imported in `index.ts` but unused)
+
+Repo-wide checks:
+```zsh
+# Direct imports (should return nothing)
+grep -R --line-number --include='*.ts' "from './openaiService" supabase/functions/generate-style-preview || true
+grep -R --line-number --include='*.ts' "from './imageGenerationService" supabase/functions/generate-style-preview || true
+grep -R --line-number --include='*.ts' "from './canvasWatermarkService" supabase/functions/generate-style-preview || true
+grep -R --line-number --include='*.ts' "from './stylePrompts" supabase/functions/generate-style-preview || true
+grep -R --line-number --include='*.ts' "from './types'\" supabase/functions/generate-style-preview | grep -v 'replicate/types' || true
+
+# Dynamic import guard (should not reference targets)
+grep -R --line-number --include='*.ts' "import\\(" supabase/functions/generate-style-preview | \
+  grep -E "openaiService|imageGenerationService|canvasWatermarkService|stylePrompts|/types\\.ts" || true
+
+# Dead code tools
+npm run dead-code:check
+npm run lint:unused
+```
+
+Keep-for-now (exclude from deletion without owner sign-off):
+- `imageAnalysisService.ts` (unused but plausible future analysis)
+- `watermarkService.ts` (dynamic Imagescript import; keep isolated and not imported by `index.ts`)
+
+---
+
+## Production Flip & Rollback
+- [ ] Gate flag: introduce `USE_GENERATE_PREVIEW_V2` env; router reads it at request time (or boot) to choose v1 vs v2
+- [ ] Webhook: configure Replicate webhook URL to v2 handler; set shared secret; verify signature; accept `succeeded|failed|canceled`
+- [ ] Canary: route 10–20% to v2; monitor p50/p95 + error rate + logs; compare to v1
+- [ ] Success criteria: p95 improves vs v1; error rate not worse; no schema/code regressions
+- [ ] Flip: set flag to 100% v2; keep v1 deployed for one release window
+- [ ] Rollback: toggle `USE_GENERATE_PREVIEW_V2=false`; optionally disable Replicate webhook to stop callbacks
+
+---
+
+## Notes & Tips
+- Use identical prompts and params for apples-to-apples latency comparisons.
+- Node 18+ recommended for the metric harness (built-in `fetch`).
+- For v2 async, prefer persisting completion to Supabase with `requestId`; the harness can be extended to poll your status endpoint.

--- a/scripts/measure-latency.ts
+++ b/scripts/measure-latency.ts
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+/*
+  Simple harness to measure p50/p95 latency for the edge function.
+  - Makes N POST requests with provided JSON body
+  - Extracts `.duration` from response JSON; if not present, measures wall time
+  - Writes results to stdout and an optional output file
+
+  Usage:
+    node scripts/measure-latency.ts \
+      --url https://<edge-domain>/functions/v1/generate-style-preview \
+      --body ./scripts/sample-body.json \
+      --count 100 \
+      --concurrency 5 \
+      --out v1_durations.txt
+
+  For v2 async mode, supply a status endpoint hook via --status-url and a field --request-id-key if needed.
+*/
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+interface Args {
+  url: string;
+  bodyPath?: string;
+  bodyInline?: string;
+  count: number;
+  concurrency: number;
+  out?: string;
+  warmup: number;
+  headers?: string[];
+}
+
+function parseArgs(): Args {
+  const args = process.argv.slice(2);
+  const get = (flag: string) => {
+    const i = args.indexOf(flag);
+    return i >= 0 ? args[i + 1] : undefined;
+  };
+  const url = get('--url');
+  if (!url) {
+    console.error('Missing --url');
+    process.exit(1);
+  }
+  const bodyPath = get('--body');
+  const bodyInline = get('--body-inline');
+  const count = parseInt(get('--count') || '50', 10);
+  const concurrency = parseInt(get('--concurrency') || '5', 10);
+  const out = get('--out');
+  const warmup = parseInt(get('--warmup') || '5', 10);
+  const headersArg = get('--headers');
+  const headers = headersArg ? headersArg.split(',') : undefined; // e.g. "Authorization: Bearer X-Token"
+  return { url, bodyPath, bodyInline, count, concurrency, out, warmup, headers } as Args;
+}
+
+function parseHeaders(kvs?: string[]): Record<string, string> | undefined {
+  if (!kvs) return undefined;
+  const h: Record<string, string> = {};
+  for (const kv of kvs) {
+    const idx = kv.indexOf(':');
+    if (idx === -1) continue;
+    const k = kv.slice(0, idx).trim();
+    const v = kv.slice(idx + 1).trim();
+    if (k) h[k] = v;
+  }
+  return h;
+}
+
+function percentile(values: number[], p: number): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const idx = Math.floor(p * (sorted.length - 1));
+  return sorted[idx];
+}
+
+async function main() {
+  const { url, bodyPath, bodyInline, count, concurrency, out, warmup, headers } = parseArgs();
+  const hdrs: Record<string, string> = { 'Content-Type': 'application/json', ...(parseHeaders(headers) || {}) };
+  const body = bodyInline
+    ? bodyInline
+    : bodyPath
+    ? fs.readFileSync(path.resolve(bodyPath), 'utf8')
+    : JSON.stringify({ imageUrl: 'data:image/png;base64,', style: 'Classic Oil Painting', aspectRatio: '1:1', quality: 'medium' });
+
+  const results: number[] = [];
+
+  async function oneRun(i: number, warmupMode = false) {
+    const t0 = Date.now();
+    const res = await fetch(url, { method: 'POST', headers: hdrs, body });
+    const t1 = Date.now();
+    let dur = t1 - t0;
+    try {
+      const json = await res.json();
+      if (typeof json?.duration === 'number') {
+        dur = json.duration;
+      }
+    } catch (_err) {
+      // ignore JSON parse errors; fallback to wall-clock duration
+    }
+    if (!warmupMode) results.push(dur);
+  }
+
+  // Warm-up
+  for (let i = 0; i < warmup; i++) {
+    await oneRun(i, true);
+  }
+
+  // Concurrent runs
+  let inFlight = 0;
+  let idx = 0;
+  await new Promise<void>((resolve) => {
+    const pump = () => {
+      while (inFlight < concurrency && idx < count) {
+        const i = idx++;
+        inFlight++;
+        oneRun(i).finally(() => {
+          inFlight--;
+          if (results.length >= count) resolve();
+          else pump();
+        });
+      }
+    };
+    pump();
+  });
+
+  const p50 = percentile(results, 0.5);
+  const p95 = percentile(results, 0.95);
+  const min = Math.min(...results);
+  const max = Math.max(...results);
+  const avg = Math.round(results.reduce((a, b) => a + b, 0) / results.length);
+
+  const report = { samples: results.length, min, p50, p95, max, avg };
+  console.log(JSON.stringify(report));
+
+  if (out) {
+    const lines = results.map((d, i) => `${i + 1} ${d}`).join('\n');
+    fs.writeFileSync(out, lines + '\n');
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/sample-body.json
+++ b/scripts/sample-body.json
@@ -1,0 +1,6 @@
+{
+  "imageUrl": "data:image/png;base64,",
+  "style": "Classic Oil Painting",
+  "aspectRatio": "1:1",
+  "quality": "medium"
+}

--- a/supabase/functions/generate-style-preview-v2/index.ts
+++ b/supabase/functions/generate-style-preview-v2/index.ts
@@ -1,0 +1,199 @@
+// @ts-nocheck
+import "https://deno.land/x/xhr@0.1.0/mod.ts";
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.7.1";
+import { handleCorsPreflightRequest, createCorsResponse } from "../generate-style-preview/corsUtils.ts";
+import { validateRequest } from "../generate-style-preview/requestValidator.ts";
+import { createSuccessResponse, createErrorResponse } from "../generate-style-preview/responseUtils.ts";
+import { StylePromptService } from "../generate-style-preview/stylePromptService.ts";
+import { PromptEnhancer } from "../generate-style-preview/replicate/promptEnhancer.ts";
+
+// Minimal v2: single create call (no polling), webhook for completion, optional GET /status
+serve(async (req) => {
+  // CORS preflight
+  if (req.method === "OPTIONS") return handleCorsPreflightRequest();
+
+  const url = new URL(req.url);
+  const pathname = url.pathname;
+
+  // Route: POST /webhook (Replicate callback)
+  if (req.method === "POST" && pathname.endsWith("/webhook")) {
+    try {
+      const secret = Deno.env.get("V2_WEBHOOK_SECRET");
+      const token = url.searchParams.get("token");
+      if (!secret || token !== secret) {
+        return createCorsResponse(JSON.stringify({ ok: false, error: "unauthorized" }), 401);
+      }
+
+      const body = await req.json();
+      const predictionId = body?.id as string | undefined;
+      const status = body?.status as string | undefined;
+      const input = body?.input || {};
+      const requestId = input?.request_id as string | undefined;
+      let output = body?.output as string | string[] | undefined;
+      if (Array.isArray(output)) output = output[0];
+      const errorMsg = body?.error as string | undefined;
+
+      const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+      const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+      const sb = createClient(supabaseUrl, supabaseServiceKey);
+
+      // Idempotent upsert by requestId or predictionId
+      const upsertPayload: Record<string, unknown> = {
+        request_id: requestId ?? null,
+        prediction_id: predictionId ?? null,
+        status: status ?? "unknown",
+        preview_url: output ?? null,
+        error: errorMsg ?? null,
+        updated_at: new Date().toISOString(),
+      };
+
+      await sb.from("previews_status").upsert(upsertPayload, { onConflict: "request_id" });
+      return createCorsResponse(JSON.stringify({ ok: true }), 200);
+    } catch (_e) {
+      return createCorsResponse(JSON.stringify({ ok: false, error: "webhook_error" }), 500);
+    }
+  }
+
+  // Route: GET /status?requestId=...
+  if (req.method === "GET" && pathname.endsWith("/status")) {
+    const requestId = url.searchParams.get("requestId");
+    if (!requestId) return createCorsResponse(JSON.stringify({ error: "missing_requestId" }), 400);
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+    const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+    const sb = createClient(supabaseUrl, supabaseServiceKey);
+    const { data, error } = await sb
+      .from("previews_status")
+      .select("request_id,status,preview_url,error,prediction_id,updated_at")
+      .eq("request_id", requestId)
+      .single();
+    if (error) return createCorsResponse(JSON.stringify({ error: "not_found" }), 404);
+    return createCorsResponse(JSON.stringify(data), 200);
+  }
+
+  // Route: POST / (create prediction)
+  if (req.method !== "POST") {
+    return createCorsResponse(
+      JSON.stringify(createErrorResponse("method_not_allowed", "Method not allowed")),
+      405,
+    );
+  }
+
+  const startTime = Date.now();
+  const requestId = `req_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+
+  try {
+    const body = await req.json();
+    const validation = validateRequest(body);
+    if (!validation.isValid) {
+      return createCorsResponse(
+        JSON.stringify(createErrorResponse("invalid_request", validation.error!)),
+        400,
+      );
+    }
+
+    const { imageUrl, style, aspectRatio, quality } = validation.data!;
+
+    const openaiApiKey = Deno.env.get("OPENAI_API_KEY");
+    const replicateApiToken = Deno.env.get("REPLICATE_API_TOKEN");
+    if (!openaiApiKey || !replicateApiToken) {
+      return createCorsResponse(
+        JSON.stringify(createErrorResponse("configuration_error", "AI service configuration error")),
+        500,
+      );
+    }
+
+    // Supabase for prompts + status row
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+    const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+    const sb = createClient(supabaseUrl, supabaseServiceKey);
+    const stylePromptService = new StylePromptService(sb);
+
+    let stylePrompt: string;
+    try {
+      const fetched = await stylePromptService.getStylePrompt(style);
+      stylePrompt = fetched || `Transform this image into ${style} style while keeping the exact same subject, composition, and scene. Apply only the artistic style transformation. Do not change what is depicted in the image - only change how it looks artistically.`;
+    } catch {
+      stylePrompt = `Transform this image into ${style} style while keeping the exact same subject, composition, and scene. Apply only the artistic style transformation. Do not change what is depicted in the image - only change how it looks artistically.`;
+    }
+
+    const enhancedPrompt = PromptEnhancer.enhanceForIdentityPreservation(stylePrompt);
+
+    // Build webhook URL
+    const base = Deno.env.get("V2_WEBHOOK_BASE_URL");
+    const secret = Deno.env.get("V2_WEBHOOK_SECRET");
+    if (!base || !secret) {
+      return createCorsResponse(
+        JSON.stringify(createErrorResponse("configuration_error", "Webhook not configured")),
+        500,
+      );
+    }
+    const webhookUrl = `${base.replace(/\/$/, "")}/functions/v1/generate-style-preview-v2/webhook?token=${secret}`;
+
+    // Create prediction (no Prefer: wait)
+    const createBody = {
+      input: {
+        prompt: enhancedPrompt,
+        input_images: [imageUrl],
+        openai_api_key: openaiApiKey,
+        aspect_ratio: aspectRatio,
+        quality: quality,
+        request_id: requestId,
+      },
+      webhook: webhookUrl,
+      webhook_events_filter: ["completed", "failed", "canceled"],
+    } as const;
+
+    const resp = await fetch("https://api.replicate.com/v1/models/openai/gpt-image-1/predictions", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${replicateApiToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(createBody),
+    });
+
+    if (!resp.ok) {
+      const errTxt = await resp.text();
+      return createCorsResponse(
+        JSON.stringify(createErrorResponse("generation_failed", `GPT-Image-1 API request failed: ${resp.status} - ${errTxt}`)),
+        503,
+      );
+    }
+
+    const data = await resp.json();
+
+    // If immediate success (rare), finalize now and persist
+    if (data?.status === "succeeded" && data?.output) {
+      let out = data.output as string | string[];
+      if (Array.isArray(out)) out = out[0];
+      await sb.from("previews_status").upsert({
+        request_id: requestId,
+        prediction_id: data?.id ?? null,
+        status: "succeeded",
+        preview_url: out,
+        error: null,
+        updated_at: new Date().toISOString(),
+      }, { onConflict: "request_id" });
+      const duration = Date.now() - startTime;
+      return createCorsResponse(JSON.stringify(createSuccessResponse(out as string, requestId, duration)), 200);
+    }
+
+    // Otherwise, store processing state and return 202 with requestId
+    await sb.from("previews_status").upsert({
+      request_id: requestId,
+      prediction_id: data?.id ?? null,
+      status: data?.status ?? "processing",
+      preview_url: null,
+      error: null,
+      updated_at: new Date().toISOString(),
+    }, { onConflict: "request_id" });
+
+    return createCorsResponse(JSON.stringify({ requestId, status: data?.status ?? "processing" }), 202);
+  } catch (_error) {
+    return createCorsResponse(
+      JSON.stringify(createErrorResponse("internal_error", "Internal server error. Please try again.")),
+      500,
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- add scripts and documentation for measuring preview latency against replicate v2
- restructure product progress/momentum components to support async preview instrumentation
- introduce dedicated animation/style sheets and a new Supabase edge function for async previews

## Testing
- npm run build
- npm run lint (fails: known repo-wide unused var / any warnings)