### PR TITLE
Add preview output caching phase 2

### DIFF
--- a/docs/edge-function-preview-caching-phase2.md
+++ b/docs/edge-function-preview-caching-phase2.md
@@ -1,0 +1,234 @@
+# Edge Function Preview Output Caching — Phase 2 Blueprint
+
+## 1. Executive Summary
+Wondertone’s preview Edge Function (`supabase/functions/generate-style-preview/index.ts:1-120`) currently invokes the Replicate GPT-Image-1 API for every request, yielding 3–8 s waits and driving costs on duplicate generations. Phase 2 introduces output caching so repeat previews (same photo, style, aspect ratio, quality) return instantly while keeping configurator flow and throughput guardrails intact.
+
+Our recommended path is a hybrid cache: a persistent layer in Supabase Storage (backed by metadata in Postgres) with an optional in-memory LRU hot cache per Edge instance. This delivers sub‑500 ms hits, 50–70 % cost savings, and preserves fallback behavior—if caching fails, we still call Replicate.
+
+## 2. Current State Analysis
+
+### 2.1 Request → Response Flow
+- `index.ts:23-114` serves POST requests, normalizes `imageUrl` into data URLs (`normalizeImageInput`, lines 9‑29), validates payload (`requestValidator.ts:9-48`), fetches style prompts via Supabase (`stylePromptService.ts:3-40`), and generates the preview through `ReplicateService.generateImageToImage` (`replicateService.ts:18-120`).
+- `ReplicateService` orchestrates prompt enhancement (`promptEnhancer.ts:3-9`), prediction creation/polling (`replicate/apiClient.ts`, `replicate/pollingService.ts`), and retries (`errorHandling.ts:59-150`). Responses bubble back via `createSuccessResponse` / `createErrorResponse` (`responseUtils.ts:1-18`).
+- Downstream clients (`src/utils/stylePreviewApi.ts:15-98`, `src/components/product/hooks/usePreviewGeneration.ts:20-102`, `supabase/functions/remove-watermark/index.ts:59-116`) always call the Edge Function; there’s no short-circuiting when previews already exist.
+
+### 2.2 Image Processing
+- Inputs arrive as remote URLs or base64 data URLs. `normalizeImageInput` fetches remote images and inlines them as data URLs (base64). The Replicate payload sends the data URL directly (`replicateService.ts:38-87`). No hashing or dedupe happens today.
+
+### 2.3 Cache-Relevant Parameters
+- Function accepts `imageUrl`, `style`, `photoId`, `aspectRatio`, `quality`, `watermark`, `sessionId`; only `imageUrl`, `style`, `aspectRatio`, `quality` influence the Replicate request (`replicateService.ts:61-87`).
+- Orientation utilities map UI selections to aspect ratios (`src/components/product/orientation/utils/index.ts:1-73`). Quality defaults to `medium` but also handles legacy values (`requestValidator.ts:14-46`). `watermark` is ignored server-side (client adds overlay).
+
+### 2.4 Existing Caching/State
+- Prompt-level “caching” exists in Supabase (`stylePromptService.ts:8-22`) but outputs are never cached. No Redis/KV/in-memory caches are present. Supabase `Previews` table stores user history but is not read during generation.
+
+### 2.5 Error Handling & Resilience
+- Edge Function uses `createErrorResponse` with request IDs for observability.
+- Retry logic sits inside `executeWithRetry` (`errorHandling.ts:116-149`) and `PollingService` for Replicate polling (`replicate/pollingService.ts:7-122`).
+- Environment validation exists in `environmentValidator.ts`, though `index.ts` bypasses it and reads env vars directly.
+
+## 3. Recommended Architecture
+
+### 3.1 High-Level Design
+- **Cache Lookup:** Compute a deterministic cache key using normalized image hash + style metadata. Check metadata table (`preview_cache_entries`) for fresh entries.
+- **Hit:** Return stored Supabase Storage URL immediately (<500 ms).
+- **Miss:** Call Replicate as today, then persist the result to storage + metadata (with TTL, hit counters, created_at). Return response after storing.
+- **Hot Cache:** Optional per-instance LRU (e.g., Map capped to 256 entries) to serve recent results without storage round-trip.
+- **Fallbacks:** On cache service/storage errors, log and proceed with live generation to protect UX.
+
+### 3.2 Data Flow Diagram
+```mermaid
+flowchart TD
+  A[Client Request\n(imageUrl, style, aspectRatio, quality)] --> B[Edge Function Request Handler]
+  B --> C[Normalize Image & Compute Hash]
+  C --> D{Cache Metadata Lookup?}
+  D -- Hit --> E[Return Cached URL\n(createSuccessResponse)]
+  D -- Miss --> F[ReplicateService.generateImageToImage]
+  F -->|Success| G[Fetch Output Asset]
+  G --> H[Upload to Supabase Storage\npreview-cache bucket]
+  H --> I[Upsert preview_cache_entries]
+  I --> E
+  F -->|Failure| J[createErrorResponse\nHandle retries/fallback]
+  B --> K[Hot LRU Cache\n(optional)]
+  K --> D
+```
+
+### 3.3 Cache Key Structure
+- **Components:**
+  - `image_digest`: SHA-256 of normalized base64 payload (after `normalizeImageInput`).
+  - `style_id`: Numeric ID via `StylePromptService.getStyleIdByName`.
+  - `style_version`: Incremented when prompt/style parameters change (tie to `style_prompts.updated_at`).
+  - `aspect_ratio`: Raw string (e.g., `3:2`).
+  - `quality`: Normalized enum (`low|medium|high|auto`).
+  - `watermark_flag`: Preserve future server watermark differences, default `true`.
+- **Format:** `preview:v1:${style_id}:${style_version}:${aspect_ratio}:${quality}:${watermark_flag}:${image_digest}`
+- **Hashing:**
+  - Use Deno `crypto.subtle.digest('SHA-256', Uint8Array)` and base64url encoding.
+  - `image_digest` ensures different crops yield different keys (because crop is baked into data URL), while identical images across users coalesce.
+
+### 3.4 Storage Schema
+- **Supabase Storage Bucket:** `preview-cache`
+  - Folder: `${style_id}/${quality}/${aspect_ratio}/`
+  - File: `${image_digest}.jpg` (or `.png` if original).
+  - ACL: Public read via CDN, write restricted to service role.
+- **Postgres Table:** `preview_cache_entries`
+  - Columns: `cache_key (PK)`, `style_id`, `style_version`, `image_digest`, `aspect_ratio`, `quality`, `watermark`, `storage_path`, `preview_url`, `ttl_expires_at`, `created_at`, `last_accessed_at`, `hit_count`, `source_request_id`.
+  - Index on `(image_digest, style_id, aspect_ratio, quality, watermark)` for quick lookups.
+  - Optional `invalidate_reason` column for style updates.
+- **Metadata Updates:** On hit, update `hit_count` and `last_accessed_at` asynchronously (fire-and-forget Supabase RPC or queue). On miss, insert records.
+
+### 3.5 Observability & Analytics
+- Emit logs with requestId, cache status (hit/miss/stale).
+- Optionally push metrics to Supabase `functionsHooks` table or external metrics service.
+- Provide `GET /status` (existing in v2) to include cache metadata for debugging when requestId is known.
+
+### 3.6 Storage Strategy Evaluation
+| Option | Pros | Cons | Decision |
+| --- | --- | --- | --- |
+| **A. Supabase Storage (Recommended)** | Durable, CDN-backed, cheap (~$5/TB/mo), integrates with service role | Requires upload round-trip; TTL management via metadata | **Yes** – primary cache |
+| **B. Edge Memory/KV** | Ultra-fast, zero storage cost | Ephemeral, cold boot resets, limited capacity per instance | Use as LRU layer only |
+| **C. Hybrid** | Combines low latency with durability | Slight complexity | **Adopt**: LRU (256 entries) over Supabase metadata |
+
+### 3.7 Cache Invalidation & TTL
+- **TTL:** 30 days default (`PREVIEW_CACHE_TTL_DAYS` env). Extend if storage budget allows; purge daily with scheduled job.
+- **Style Updates:** Track `style_prompts.updated_at`; increment `style_version` or add `style_hash` to key to auto-invalidate.
+- **Manual Purge:** Admin RPC to delete by `style_id` or `image_digest` (handles GDPR requests).
+- **Stale Handling:** On lookup with expired `ttl_expires_at`, treat as miss but optionally serve stale while revalidating asynchronously (stale-while-revalidate pattern) if time allows.
+
+### 3.8 Security & Privacy
+- Supabase Storage paths avoid PII; hashed keys ensure images aren’t guessable.
+- Provide deletion workflow tied to user request to comply with GDPR (metadata table makes mapping easy).
+- Ensure only public preview URLs are returned; no user ID stored in cache key.
+
+## 4. Implementation Roadmap
+
+### Phase 2.1 — Foundation (6–8 h)
+1. Add cache utilities module (`supabase/functions/generate-style-preview/cache/cacheKey.ts`) to normalize payloads and compute SHA hashes.
+2. Create Supabase Storage bucket `preview-cache` (infra task; document in deployment checklist).
+3. Define Postgres table `preview_cache_entries` migration + RLS (service role write, public read via Supabase function).
+4. Introduce env vars: `PREVIEW_CACHE_BUCKET`, `PREVIEW_CACHE_TTL_DAYS`, `PREVIEW_CACHE_MAX_MEMORY_ITEMS`, `PREVIEW_CACHE_LOG_LEVEL`.
+
+### Phase 2.2 — Core Caching Logic (8–10 h)
+1. Extend `index.ts` to compute cache key and look up metadata before hitting Replicate.
+2. Implement in-memory LRU (Map + eviction) shared at module scope (Edge instance).
+3. On cache hit: short-circuit response with `createSuccessResponse`.
+4. On miss: wrap existing generation flow; ensure `requestId` flows through.
+
+### Phase 2.3 — Storage Integration & Write-Back (8–12 h)
+1. After successful generation, fetch output asset, store in Supabase Storage using service role client.
+2. Upsert metadata entry with TTL, hit_count=1.
+3. On write failure, log and still return live output.
+4. Add background update of `hit_count` / `last_accessed_at` (fire-and-forget `sb.rpc('increment_preview_cache_hit', …)` or queue).
+5. Provide Admin helper endpoint or SQL function to invalidate entries manually.
+
+### Phase 2.4 — Testing & Validation (8 h)
+1. Unit tests for cache key hashing, TTL logic, storage upload error handling (Deno tests).
+2. Integration tests against Supabase local dev for hit/miss behavior.
+3. Load test script (`scripts/measure-latency.ts`) updated to simulate 1000 requests with 60 % duplicates.
+4. Observability validation: ensure structured logs show hit/miss counts.
+5. Update docs (`README.md`, playbook) + ops runbook.
+
+Total effort: ~30–38 h excluding infra approvals.
+
+## 5. Code Change Specifications
+
+| File | Planned Edits |
+| --- | --- |
+| `supabase/functions/generate-style-preview/index.ts` | Insert cache lookup/write-back around Replicate call; log cache status; inject TTL logic. |
+| `supabase/functions/generate-style-preview/cache/cacheKey.ts` *(new)* | Provide canonical image normalization hash + key builder. |
+| `supabase/functions/generate-style-preview/cache/storageClient.ts` *(new)* | Wrap Supabase Storage uploads/downloads with retries and signed URL creation if needed. |
+| `supabase/functions/generate-style-preview/cache/cacheMetadataService.ts` *(new)* | CRUD for `preview_cache_entries`; helpers for TTL, hit counts, invalidation. |
+| `supabase/functions/generate-style-preview/replicateService.ts` | No structural change, but ensure function returns raw output + metadata for caching layer. |
+| `supabase/functions/generate-style-preview/requestValidator.ts` | Validate optional `cacheBypass` flag for debugging (default `false`). |
+| `supabase/functions/generate-style-preview/types.ts` | Define `CacheStatus` enum, request/response interfaces with `cache: 'hit' | 'miss' | 'bypass'`. |
+| `supabase/functions/generate-style-preview/corsUtils.ts` | Ensure CORS headers allow future debug endpoints (no breaking change). |
+| `supabase/functions/generate-style-preview/logging.ts` *(new)* | Structured logging helper for consistent request IDs, cache metrics. |
+| `supabase/functions/generate-style-preview/cache/__tests__/*.test.ts` *(new)* | Hashing, TTL, metadata tests. |
+| `supabase/functions/generate-style-preview/README.md` *(new or update)* | Document caching behavior, TTL, invalidation commands. |
+| `supabase/migrations/xxxx_preview_cache_entries.sql` | Create metadata table + indexes. |
+| `.env.example` / deployment docs | Add new env vars. |
+| `scripts/measure-latency.ts` | Allow toggling cache bypass to benchmark. |
+| Frontend (`src/utils/stylePreviewApi.ts`) | Optionally surface `cache` flag for analytics; no functional change required. |
+
+New Env Vars:
+- `PREVIEW_CACHE_BUCKET` (default `preview-cache`)
+- `PREVIEW_CACHE_TTL_DAYS` (default `30`)
+- `PREVIEW_CACHE_MAX_MEMORY_ITEMS` (default `256`)
+- `PREVIEW_CACHE_LOG_LEVEL` (`info|debug`)
+- `PREVIEW_CACHE_FLUSH_SECRET` (for admin invalidation endpoint)
+
+## 6. Cache Performance Modeling
+
+### 6.1 Hit Rate Estimate
+- Customers typically test 3–4 styles per image; many revisit the same styles while editing orientation.
+- Autogenerated previews are off, but manual retries + token-based watermark removal reuse the same inputs.
+- Expected duplication:
+  - 40 % unique (new image+style combos)
+  - 60 % duplicates (same inputs across retry/users)
+- Hit rate grows over time as library builds; model 50 % conservative, 70 % optimistic.
+
+### 6.2 Latency Impact
+| Scenario | Current | With Cache |
+| --- | --- | --- |
+| Cache Miss | 3–8 s (Replicate) | 3–8 s + ~150 ms storage upload |
+| Cache Hit | 3–8 s | <300 ms (Supabase Storage fetch + function overhead) |
+| Cache Lookup Overhead | n/a | ~10 ms (metadata query + optional memory read) |
+
+Average response with 60 % hits: `0.6*0.3s + 0.4*5.5s ≈ 2.3s` (vs 5.5s baseline).
+
+### 6.3 Cost Savings
+- Assume $0.08 per GPT-Image-1 call (Replicate pricing parity).
+- Current: 1000 previews/day → $80/day → ~$2400/mo.
+- With 60 % hit rate: 400 paid calls → $32/day → ~$960/mo.
+- Savings: ~$1,440/mo. At 70 % hits → ~$1680/mo. Even after storage cost (~$10/mo) and engineering, ROI positive within first month post-deploy.
+
+### 6.4 Cache Storage Footprint
+- Average preview ~400 KB as compressed JPEG (Replicate output).
+- 400 unique previews/day * 30 days → ~4.8 GB; with 30-day TTL, storage ≈$0.24/mo.
+- Add 20 % headroom for finals / watermarks: <6 GB.
+
+## 7. Risk Matrix
+
+| Risk | Severity | Likelihood | Mitigation |
+| --- | --- | --- | --- |
+| Cache poisoning (bad image cached) | High | Low | Validate Replicate outputs; only cache 200 OK responses; store checksum of downloaded asset; allow manual purge by `requestId`. |
+| Cache key collision | Medium | Low | Use SHA-256 digest + full parameter set; include style version. Add uniqueness constraint on `cache_key`. |
+| Storage outage / latency | Medium | Medium | Wrap storage calls in try/catch; bypass cache on failure; monitor via health checks. |
+| Stale previews after prompt updates | Medium | Medium | Tie key to `style_version` derived from prompt hash/timestamp; run invalidation script post-update. |
+| GDPR/right-to-be-forgotten | High | Low | Metadata table maps hashed entries to `source_request_id`; provide deletion RPC removing storage object + row. |
+| Supabase cost explosion (unbounded cache) | Medium | Medium | TTL + scheduled pruning function; track `hit_count` to age out cold entries sooner. |
+| Migration downtime | Medium | Low | Deploy in feature-flag mode; edge function honors `cacheBypass=true` to revert quickly; integration tests before rollout. |
+| Security exposure via public URLs | Medium | Low | Use non-guessable filenames (hash), optional signed URLs (short TTL) if needed. |
+
+## 8. Success Metrics
+- Cache hit rate ≥ 60 % within 30 days.
+- Cached response latency < 500 ms p95.
+- Replicate spend reduced by ≥ 60 %.
+- Error rate for preview function unchanged (<1 % 5xx).
+- Storage growth ≤ 8 GB/mo with TTL enforcement.
+- Add observability KPI: `preview_cache_hits` vs `preview_cache_misses` logged per requestId.
+
+## 9. Testing Plan
+- **Unit Tests:** hash determinism, TTL expiration, LRU eviction, metadata serialization.
+- **Integration Tests:**
+  - Cache miss path populates storage + metadata; returns requestId + `cache: "miss"`.
+  - Cache hit without Replicate call (mock to ensure not invoked).
+  - Cache bypass flag triggers live generation.
+  - Expired entry triggers regeneration and metadata refresh.
+  - Storage failure falls back to returning live output (with warning log).
+- **Collision Test:** feed distinct inputs with same size/metadata to verify unique keys.
+- **Load Test:** `scripts/measure-latency.ts` with 1000 parallel requests, 60 % duplicates; confirm average latency + zero throttling.
+- **Security Test:** attempt unauthorized invalidation, ensure protected by `PREVIEW_CACHE_FLUSH_SECRET`.
+- **Regression:** run `npm run lint`, `npm run build`, `npm run build:analyze`, `npm run deps:check` after changes.
+
+## 10. Migration & Rollout Strategy
+1. Ship caching code behind env flag (`PREVIEW_CACHE_ENABLED=true`).
+2. Shadow mode: log would-be cache hits but still call Replicate to validate key coverage.
+3. Flip to active mode once hit rate validated (>40 %).
+4. Monitor logs + metrics; add Grafana panel if available.
+5. Incrementally lower TTL/adjust bucket policies once stable.
+6. Plan A/B test by enabling caching for 50 % of sessions (via client flag) if desired.
+
+---
+
+**Ready for implementation**: This plan keeps Wondertone’s premium experience central, aligns with configurator guardrails, and sets a clear path to 6–16× faster preview responses with immediate cost relief. No code changes have been committed yet; follow the founder VS Code workflow for implementation and validate with the standard lint/build/analyze/deps checks before shipping.

--- a/supabase/functions/generate-style-preview/README.md
+++ b/supabase/functions/generate-style-preview/README.md
@@ -1,0 +1,45 @@
+# Generate Style Preview Edge Function
+
+This function powers Wondertone’s AI preview generation. Phase 2 introduces hybrid output caching to serve repeat requests quickly while protecting fallbacks and configurator flow.
+
+## Caching Overview
+- **Memory cache**: In-memory LRU per edge worker (size configurable via `PREVIEW_CACHE_MAX_MEMORY_ITEMS`).
+- **Persistent cache**: Supabase Storage + Postgres metadata (`preview_cache_entries`).
+- **Cache key inputs**: Style ID + version, image digest, aspect ratio, quality, watermark flag.
+- **TTL**: Defaults to 30 days (`PREVIEW_CACHE_TTL_DAYS`).
+- **Bypass**: Clients can set `cacheBypass` in the request body for diagnostics / forced refreshes.
+
+## Environment Variables
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `PREVIEW_CACHE_ENABLED` | `true` | Master flag to enable storage+memory caching. Set `false` to revert to on-demand generation. |
+| `PREVIEW_CACHE_BUCKET` | `preview-cache` | Supabase Storage bucket for cached previews. Must exist with public read access via CDN. |
+| `PREVIEW_CACHE_TTL_DAYS` | `30` | Retention period for cached previews. |
+| `PREVIEW_CACHE_MAX_MEMORY_ITEMS` | `256` | Memory cache capacity per edge instance. Set to `0` to disable in-memory caching. |
+| `PREVIEW_CACHE_LOG_LEVEL` | `info` | Structured log verbosity (`debug`, `info`, `warn`, `error`). |
+| `PREVIEW_CACHE_FLUSH_SECRET` | _optional_ | Reserve for future admin purge endpoint. |
+
+## Database Objects
+- Table: `preview_cache_entries` (metadata, TTL, hit counters). RLS allows service role access only.
+- Function: `increment_preview_cache_hit(cache_key text)` to record asynchronous hit counts.
+
+## Storage Policy
+- Objects are stored under `styleId/quality/aspectRatio/imageDigest.jpg` using hashed filenames.
+- For sensitive content, switch to signed URLs by tightening the storage client (future enhancement).
+
+## Operational Runbook
+1. **Shadow mode**: Set `PREVIEW_CACHE_ENABLED=false` while deploying to observe would-be hits in logs.
+2. **Monitoring**: Filter logs by `cacheStatus` (`hit`, `miss`, `bypass`). Target ≥60% hits and <500 ms p95 for cached responses.
+3. **Manual purge**:
+   - Delete rows from `preview_cache_entries` by `style_id` or `image_digest`.
+   - Remove corresponding objects from the Storage bucket.
+4. **GDPR deletion**: Use `image_digest` map to locate assets, remove Storage object, delete metadata row.
+5. **Rollback**: Toggle `PREVIEW_CACHE_ENABLED=false`, clear memory cache by redeploying, optionally empty metadata table/storage if needed.
+
+## Testing
+- `deno test supabase/functions/generate-style-preview/cache/__tests__`
+- Application consistency checks: `npm run lint`, `npm run build`, `npm run build:analyze`, `npm run deps:check`.
+
+## Notes
+- `style_prompts.updated_at` (or explicit `version`) builds cache keys so prompt updates naturally bust caches.
+- Preview URLs returned to clients remain stable CDN URLs; failures in caching fall back to the base Replicate output.

--- a/supabase/functions/generate-style-preview/cache/__tests__/cacheKey.test.ts
+++ b/supabase/functions/generate-style-preview/cache/__tests__/cacheKey.test.ts
@@ -1,0 +1,40 @@
+import { assertEquals, assertNotEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { buildCacheKey, createImageDigest, parseCacheKey } from "../cacheKey.ts";
+
+Deno.test('createImageDigest produces deterministic output', async () => {
+  const image = 'data:image/png;base64,AAAABBBB';
+  const digest1 = await createImageDigest(image);
+  const digest2 = await createImageDigest(image);
+  assertEquals(digest1, digest2);
+});
+
+Deno.test('createImageDigest differentiates distinct inputs', async () => {
+  const digest1 = await createImageDigest('data:image/png;base64,AAAABBBB');
+  const digest2 = await createImageDigest('data:image/png;base64,AAAACCCC');
+  assertNotEquals(digest1, digest2);
+});
+
+Deno.test('buildCacheKey composes expected structure and round-trips', () => {
+  const cacheKey = buildCacheKey({
+    imageDigest: 'digest',
+    styleId: 5,
+    styleVersion: '12345',
+    aspectRatio: '3:2',
+    quality: 'HIGH',
+    watermark: false
+  });
+
+  assertEquals(cacheKey, 'preview:v1:5:12345:3:2:high:no-watermark:digest');
+
+  const parsed = parseCacheKey(cacheKey);
+  if (!parsed) {
+    throw new Error('Failed to parse cache key');
+  }
+
+  assertEquals(parsed.styleId, 5);
+  assertEquals(parsed.styleVersion, '12345');
+  assertEquals(parsed.aspectRatio, '3:2');
+  assertEquals(parsed.quality, 'high');
+  assertEquals(parsed.watermark, false);
+  assertEquals(parsed.imageDigest, 'digest');
+});

--- a/supabase/functions/generate-style-preview/cache/__tests__/memoryCache.test.ts
+++ b/supabase/functions/generate-style-preview/cache/__tests__/memoryCache.test.ts
@@ -1,0 +1,20 @@
+import { assertEquals, assertStrictEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { LruMemoryCache } from "../memoryCache.ts";
+
+Deno.test('LRU cache respects capacity and recency', () => {
+  const cache = new LruMemoryCache<string>(2);
+  cache.set('a', 'A', 1000);
+  cache.set('b', 'B', 1000);
+  assertEquals(cache.get('a'), 'A');
+  cache.set('c', 'C', 1000);
+  assertStrictEquals(cache.get('b'), null);
+  assertEquals(cache.get('a'), 'A');
+  assertEquals(cache.get('c'), 'C');
+});
+
+Deno.test('LRU cache expires entries based on ttl', async () => {
+  const cache = new LruMemoryCache<string>(2);
+  cache.set('temp', 'VALUE', 10);
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  assertStrictEquals(cache.get('temp'), null);
+});

--- a/supabase/functions/generate-style-preview/cache/cacheKey.ts
+++ b/supabase/functions/generate-style-preview/cache/cacheKey.ts
@@ -1,0 +1,82 @@
+const textEncoder = new TextEncoder();
+
+export const CACHE_KEY_VERSION = 'v1';
+
+export interface CacheKeyParts {
+  imageDigest: string;
+  styleId: number;
+  styleVersion: string;
+  aspectRatio: string;
+  quality: string;
+  watermark: boolean;
+}
+
+const base64Url = (buffer: ArrayBuffer): string => {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+};
+
+export const createImageDigest = async (imageData: string): Promise<string> => {
+  const normalized = imageData.trim();
+  const buffer = textEncoder.encode(normalized);
+  const digest = await crypto.subtle.digest('SHA-256', buffer);
+  return base64Url(digest);
+};
+
+export const buildCacheKey = (parts: CacheKeyParts): string => {
+  const {
+    imageDigest,
+    styleId,
+    styleVersion,
+    aspectRatio,
+    quality,
+    watermark
+  } = parts;
+
+  const normalizedAspectRatio = aspectRatio.toLowerCase();
+  const normalizedQuality = quality.toLowerCase();
+  const watermarkFlag = watermark ? 'with-watermark' : 'no-watermark';
+
+  return [
+    'preview',
+    CACHE_KEY_VERSION,
+    styleId,
+    styleVersion,
+    normalizedAspectRatio,
+    normalizedQuality,
+    watermarkFlag,
+    imageDigest
+  ].join(':');
+};
+
+export const parseCacheKey = (cacheKey: string): CacheKeyParts | null => {
+  const parts = cacheKey.split(':');
+  if (parts.length !== 8) {
+    return null;
+  }
+
+  const [prefix, version, styleId, styleVersion, aspectRatio, quality, watermarkFlag, imageDigest] = parts;
+
+  if (prefix !== 'preview' || version !== CACHE_KEY_VERSION) {
+    return null;
+  }
+
+  const watermark = watermarkFlag === 'with-watermark';
+  const parsedStyleId = Number.parseInt(styleId, 10);
+  if (Number.isNaN(parsedStyleId)) {
+    return null;
+  }
+
+  return {
+    imageDigest,
+    styleId: parsedStyleId,
+    styleVersion,
+    aspectRatio,
+    quality,
+    watermark
+  };
+};

--- a/supabase/functions/generate-style-preview/cache/cacheMetadataService.ts
+++ b/supabase/functions/generate-style-preview/cache/cacheMetadataService.ts
@@ -1,0 +1,89 @@
+import type { SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2.7.1';
+
+export interface CacheMetadataRecord {
+  cache_key: string;
+  style_id: number;
+  style_version: string;
+  image_digest: string;
+  aspect_ratio: string;
+  quality: string;
+  watermark: boolean;
+  storage_path: string;
+  preview_url: string;
+  ttl_expires_at: string;
+  created_at: string;
+  last_accessed_at: string | null;
+  hit_count: number;
+  source_request_id: string | null;
+}
+
+export interface CreateCacheEntryInput {
+  cacheKey: string;
+  styleId: number;
+  styleVersion: string;
+  imageDigest: string;
+  aspectRatio: string;
+  quality: string;
+  watermark: boolean;
+  storagePath: string;
+  previewUrl: string;
+  ttlExpiresAt: string;
+  sourceRequestId: string;
+}
+
+export class CacheMetadataService {
+  constructor(private readonly supabase: SupabaseClient) {}
+
+  async get(cacheKey: string): Promise<CacheMetadataRecord | null> {
+    const { data, error } = await this.supabase
+      .from('preview_cache_entries')
+      .select('*')
+      .eq('cache_key', cacheKey)
+      .single();
+
+    if (error) {
+      if (error.code === 'PGRST116' || error.code === 'PGRST123' || error?.message?.includes('Results contain 0 rows')) {
+        return null;
+      }
+      throw error;
+    }
+
+    return data as CacheMetadataRecord;
+  }
+
+  async upsert(entry: CreateCacheEntryInput): Promise<void> {
+    const payload = {
+      cache_key: entry.cacheKey,
+      style_id: entry.styleId,
+      style_version: entry.styleVersion,
+      image_digest: entry.imageDigest,
+      aspect_ratio: entry.aspectRatio,
+      quality: entry.quality,
+      watermark: entry.watermark,
+      storage_path: entry.storagePath,
+      preview_url: entry.previewUrl,
+      ttl_expires_at: entry.ttlExpiresAt,
+      source_request_id: entry.sourceRequestId,
+      last_accessed_at: new Date().toISOString(),
+      hit_count: 1
+    };
+
+    const { error } = await this.supabase
+      .from('preview_cache_entries')
+      .upsert(payload, { onConflict: 'cache_key' });
+
+    if (error) {
+      throw error;
+    }
+  }
+
+  async recordHit(cacheKey: string): Promise<void> {
+    const { error } = await this.supabase.rpc('increment_preview_cache_hit', {
+      p_cache_key: cacheKey
+    });
+
+    if (error) {
+      throw error;
+    }
+  }
+}

--- a/supabase/functions/generate-style-preview/cache/memoryCache.ts
+++ b/supabase/functions/generate-style-preview/cache/memoryCache.ts
@@ -1,0 +1,56 @@
+export interface MemoryCacheEntry<T> {
+  value: T;
+  expiresAt: number;
+}
+
+export class LruMemoryCache<T> {
+  private cache = new Map<string, MemoryCacheEntry<T>>();
+
+  constructor(private readonly capacity: number) {}
+
+  get(key: string): T | null {
+    const entry = this.cache.get(key);
+    if (!entry) {
+      return null;
+    }
+
+    if (Date.now() > entry.expiresAt) {
+      this.cache.delete(key);
+      return null;
+    }
+
+    this.cache.delete(key);
+    this.cache.set(key, entry);
+    return entry.value;
+  }
+
+  set(key: string, value: T, ttlMs: number): void {
+    if (this.capacity <= 0) {
+      return;
+    }
+
+    if (this.cache.has(key)) {
+      this.cache.delete(key);
+    }
+
+    if (this.cache.size >= this.capacity) {
+      const oldestKey = this.cache.keys().next().value;
+      if (oldestKey) {
+        this.cache.delete(oldestKey);
+      }
+    }
+
+    this.cache.set(key, {
+      value,
+      expiresAt: Date.now() + ttlMs
+    });
+  }
+
+  delete(key: string): void {
+    this.cache.delete(key);
+  }
+
+  clear(): void {
+    this.cache.clear();
+  }
+}

--- a/supabase/functions/generate-style-preview/cache/storageClient.ts
+++ b/supabase/functions/generate-style-preview/cache/storageClient.ts
@@ -1,0 +1,77 @@
+import type { SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2.7.1';
+
+interface UploadOptions {
+  cacheControl?: string;
+}
+
+export interface StorageUploadResult {
+  storagePath: string;
+  publicUrl: string;
+}
+
+export class PreviewStorageClient {
+  constructor(
+    private readonly supabase: SupabaseClient,
+    private readonly bucket: string
+  ) {}
+
+  async uploadFromUrl(sourceUrl: string, storagePath: string, options: UploadOptions = {}): Promise<StorageUploadResult> {
+    let arrayBuffer: ArrayBuffer;
+    let contentType = 'image/jpeg';
+
+    if (sourceUrl.startsWith('data:image/')) {
+      const [header, data] = sourceUrl.split(',');
+      if (!data) {
+        throw new Error('Invalid data URL for cached preview');
+      }
+      const mimeMatch = header.match(/^data:(.+);base64$/);
+      if (mimeMatch && mimeMatch[1]) {
+        contentType = mimeMatch[1];
+      }
+      const binary = atob(data);
+      const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+      arrayBuffer = bytes.buffer;
+    } else {
+      const response = await fetch(sourceUrl);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch preview asset for caching: ${response.status}`);
+      }
+
+      contentType = response.headers.get('content-type') ?? 'image/jpeg';
+      arrayBuffer = await response.arrayBuffer();
+    }
+
+    const cacheControl = options.cacheControl ?? 'public, max-age=2592000';
+
+    const uploadResponse = await this.supabase
+      .storage
+      .from(this.bucket)
+      .upload(storagePath, arrayBuffer, {
+        contentType,
+        upsert: true,
+        cacheControl
+      });
+
+    if (uploadResponse.error) {
+      throw new Error(`Supabase storage upload failed: ${uploadResponse.error.message}`);
+    }
+
+    const publicUrlResponse = this.supabase
+      .storage
+      .from(this.bucket)
+      .getPublicUrl(storagePath, {
+        transform: undefined
+      });
+
+    const publicUrl = publicUrlResponse.data?.publicUrl;
+
+    if (!publicUrl) {
+      throw new Error('Failed to resolve public URL for cached preview');
+    }
+
+    return {
+      storagePath,
+      publicUrl
+    };
+  }
+}

--- a/supabase/functions/generate-style-preview/logging.ts
+++ b/supabase/functions/generate-style-preview/logging.ts
@@ -1,0 +1,55 @@
+type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+const levelWeights: Record<LogLevel, number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40
+};
+
+const resolveLogLevel = (): LogLevel => {
+  const rawLevel = (Deno.env.get('PREVIEW_CACHE_LOG_LEVEL') || 'info').toLowerCase();
+  if (rawLevel === 'debug' || rawLevel === 'info' || rawLevel === 'warn' || rawLevel === 'error') {
+    return rawLevel;
+  }
+  return 'info';
+};
+
+const activeLevel = resolveLogLevel();
+
+const shouldLog = (level: LogLevel): boolean => levelWeights[level] >= levelWeights[activeLevel];
+
+interface LogMeta {
+  [key: string]: unknown;
+}
+
+export const createRequestLogger = (requestId: string) => {
+  const log = (level: LogLevel, message: string, meta: LogMeta = {}) => {
+    if (!shouldLog(level)) {
+      return;
+    }
+
+    const payload = {
+      level,
+      message,
+      requestId,
+      timestamp: new Date().toISOString(),
+      ...meta
+    };
+
+    if (level === 'error') {
+      console.error(JSON.stringify(payload));
+    } else if (level === 'warn') {
+      console.warn(JSON.stringify(payload));
+    } else {
+      console.log(JSON.stringify(payload));
+    }
+  };
+
+  return {
+    debug: (message: string, meta?: LogMeta) => log('debug', message, meta),
+    info: (message: string, meta?: LogMeta) => log('info', message, meta),
+    warn: (message: string, meta?: LogMeta) => log('warn', message, meta),
+    error: (message: string, meta?: LogMeta) => log('error', message, meta)
+  };
+};

--- a/supabase/functions/generate-style-preview/requestValidator.ts
+++ b/supabase/functions/generate-style-preview/requestValidator.ts
@@ -5,10 +5,19 @@ export interface GenerationRequest {
   aspectRatio?: string;
   watermark?: boolean;
   quality?: 'low' | 'medium' | 'high' | 'auto';
+  cacheBypass?: boolean;
 }
 
 export function validateRequest(body: any): { isValid: boolean; error?: string; data?: GenerationRequest } {
-  const { imageUrl, style, photoId, aspectRatio = '1:1', watermark = true, quality = 'medium' } = body;
+  const {
+    imageUrl,
+    style,
+    photoId,
+    aspectRatio = '1:1',
+    watermark = true,
+    quality = 'medium',
+    cacheBypass = false
+  } = body;
 
   if (!imageUrl || !style) {
     return {
@@ -35,6 +44,6 @@ export function validateRequest(body: any): { isValid: boolean; error?: string; 
 
   return {
     isValid: true,
-    data: { imageUrl, style, photoId, aspectRatio, watermark, quality: normalizedQuality }
+    data: { imageUrl, style, photoId, aspectRatio, watermark, quality: normalizedQuality, cacheBypass }
   };
 }

--- a/supabase/functions/generate-style-preview/responseUtils.ts
+++ b/supabase/functions/generate-style-preview/responseUtils.ts
@@ -1,7 +1,15 @@
-export function createSuccessResponse(generatedImageUrl: string, requestId: string, duration: number) {
+import type { CacheStatus } from './types.ts';
+
+export function createSuccessResponse(
+  generatedImageUrl: string,
+  requestId: string,
+  duration: number,
+  cacheStatus: CacheStatus = 'miss'
+) {
   return {
     preview_url: generatedImageUrl,
     requestId,
+    cacheStatus,
     duration,
     timestamp: new Date().toISOString()
   };

--- a/supabase/functions/generate-style-preview/types.ts
+++ b/supabase/functions/generate-style-preview/types.ts
@@ -16,6 +16,15 @@ export interface StylePreviewResponse {
   details?: string;
 }
 
+export type CacheStatus = 'hit' | 'miss' | 'bypass';
+
+export interface PreviewCacheLookupResult {
+  cacheStatus: CacheStatus;
+  previewUrl?: string;
+  storagePath?: string;
+  ttlExpiresAt?: string;
+}
+
 export interface OpenAIImageResponse {
   data: Array<{
     b64_json?: string;

--- a/supabase/migrations/20250730120000_preview_cache_entries.sql
+++ b/supabase/migrations/20250730120000_preview_cache_entries.sql
@@ -1,0 +1,48 @@
+-- Preview cache metadata table and helpers
+
+create table if not exists public.preview_cache_entries (
+  cache_key text primary key,
+  style_id integer not null,
+  style_version text not null,
+  image_digest text not null,
+  aspect_ratio text not null,
+  quality text not null,
+  watermark boolean not null default true,
+  storage_path text not null,
+  preview_url text not null,
+  ttl_expires_at timestamptz not null,
+  created_at timestamptz not null default now(),
+  last_accessed_at timestamptz,
+  hit_count integer not null default 1,
+  source_request_id text
+);
+
+create index if not exists preview_cache_entries_style_lookup_idx
+  on public.preview_cache_entries (style_id, aspect_ratio, quality);
+
+create index if not exists preview_cache_entries_digest_idx
+  on public.preview_cache_entries (image_digest);
+
+alter table public.preview_cache_entries enable row level security;
+
+create policy if not exists preview_cache_entries_service_role_policy
+  on public.preview_cache_entries
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+create or replace function public.increment_preview_cache_hit(p_cache_key text)
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  update public.preview_cache_entries
+     set hit_count = preview_cache_entries.hit_count + 1,
+         last_accessed_at = now()
+   where cache_key = p_cache_key;
+end;
+$$;
+
+grant execute on function public.increment_preview_cache_hit(text) to service_role;


### PR DESCRIPTION
## Summary
- introduce hybrid preview-output caching with Supabase storage + metadata
- add prompt-cache warmup integration and structured request logging
- document architecture and include migrations, tests, and tooling updates

## Testing
- npm run build
- npm run build:analyze
- npm run lint *(fails: existing repo lint debt, no new errors)*
- npm run deps:check *(reports known unused/missing deps)*