### PR TITLE
feat: add preview caching and webhook async flow

### DIFF
--- a/src/components/product/components/CustomizationStep.tsx
+++ b/src/components/product/components/CustomizationStep.tsx
@@ -15,6 +15,8 @@ interface CustomizationStepProps {
   selectedStyle?: { id: number; name: string } | null;
   previewUrls?: { [key: number]: string };
   userArtworkUrl?: string | null;
+  isGeneratingPreviews?: boolean;
+  previewError?: string | null;
   onStepClick: () => void;
 }
 
@@ -30,6 +32,8 @@ const CustomizationStep = ({
   selectedStyle,
   previewUrls,
   userArtworkUrl,
+  isGeneratingPreviews,
+  previewError,
   onStepClick
 }: CustomizationStepProps) => {
   return (
@@ -51,6 +55,8 @@ const CustomizationStep = ({
           selectedStyle={selectedStyle}
           previewUrls={previewUrls}
           userArtworkUrl={userArtworkUrl}
+          isGeneratingPreviews={isGeneratingPreviews}
+          previewError={previewError}
         />
       )}
     </ProductStepWrapper>

--- a/supabase/functions/generate-style-preview/README.md
+++ b/supabase/functions/generate-style-preview/README.md
@@ -18,10 +18,15 @@ This function powers Wondertone’s AI preview generation. Phase 2 introduces hy
 | `PREVIEW_CACHE_MAX_MEMORY_ITEMS` | `256` | Memory cache capacity per edge instance. Set to `0` to disable in-memory caching. |
 | `PREVIEW_CACHE_LOG_LEVEL` | `info` | Structured log verbosity (`debug`, `info`, `warn`, `error`). |
 | `PREVIEW_CACHE_FLUSH_SECRET` | _optional_ | Reserve for future admin purge endpoint. |
+| `PREVIEW_ASYNC_ENABLED` | `false` | Toggles webhook-driven async generation. When `true`, clients receive a `requestId` for polling. |
+| `PREVIEW_WEBHOOK_BASE_URL` | — | Public base URL (no trailing slash) for invoking the webhook endpoint. Required when async is enabled. |
+| `PREVIEW_WEBHOOK_SECRET` | — | Shared secret appended to webhook callback for verification. Required when async is enabled. |
 
 ## Database Objects
 - Table: `preview_cache_entries` (metadata, TTL, hit counters). RLS allows service role access only.
+- Table: `previews_status` (request tracking for async generation). RLS limited to service role.
 - Function: `increment_preview_cache_hit(cache_key text)` to record asynchronous hit counts.
+- Trigger: `trg_touch_previews_status` keeps `updated_at` fresh on status updates.
 
 ## Storage Policy
 - Objects are stored under `styleId/quality/aspectRatio/imageDigest.jpg` using hashed filenames.
@@ -29,12 +34,13 @@ This function powers Wondertone’s AI preview generation. Phase 2 introduces hy
 
 ## Operational Runbook
 1. **Shadow mode**: Set `PREVIEW_CACHE_ENABLED=false` while deploying to observe would-be hits in logs.
-2. **Monitoring**: Filter logs by `cacheStatus` (`hit`, `miss`, `bypass`). Target ≥60% hits and <500 ms p95 for cached responses.
-3. **Manual purge**:
+2. **Async rollout**: Enable `PREVIEW_ASYNC_ENABLED=true` only after configuring the webhook base URL + secret. Keep an eye on `/status` responses before removing the legacy polling path.
+3. **Monitoring**: Filter logs by `cacheStatus` (`hit`, `miss`, `bypass`). Target ≥60% hits and <500 ms p95 for cached responses. Track async queue health via `previews_status.status`.
+4. **Manual purge**:
    - Delete rows from `preview_cache_entries` by `style_id` or `image_digest`.
    - Remove corresponding objects from the Storage bucket.
-4. **GDPR deletion**: Use `image_digest` map to locate assets, remove Storage object, delete metadata row.
-5. **Rollback**: Toggle `PREVIEW_CACHE_ENABLED=false`, clear memory cache by redeploying, optionally empty metadata table/storage if needed.
+5. **GDPR deletion**: Use `image_digest` map to locate assets, remove Storage object, delete metadata row.
+6. **Rollback**: Toggle `PREVIEW_CACHE_ENABLED=false` and/or `PREVIEW_ASYNC_ENABLED=false`, clear memory cache by redeploying, optionally empty metadata table/storage if needed.
 
 ## Testing
 - `deno test supabase/functions/generate-style-preview/cache/__tests__`

--- a/supabase/functions/generate-style-preview/index.ts
+++ b/supabase/functions/generate-style-preview/index.ts
@@ -33,6 +33,9 @@ const ttlDays = parsePositiveInt(Deno.env.get('PREVIEW_CACHE_TTL_DAYS'), 30);
 const ttlMs = ttlDays * ONE_DAY_MS;
 const memoryCapacity = parsePositiveInt(Deno.env.get('PREVIEW_CACHE_MAX_MEMORY_ITEMS'), 256);
 const cacheBucket = Deno.env.get('PREVIEW_CACHE_BUCKET') ?? 'preview-cache';
+const asyncEnabled = (Deno.env.get('PREVIEW_ASYNC_ENABLED') ?? 'false').toLowerCase() === 'true';
+const webhookBaseUrl = Deno.env.get('PREVIEW_WEBHOOK_BASE_URL');
+const webhookSecret = Deno.env.get('PREVIEW_WEBHOOK_SECRET');
 
 const memoryCache = new LruMemoryCache<string>(memoryCapacity);
 
@@ -97,9 +100,187 @@ const computeStoragePath = (styleId: number, aspectRatio: string, quality: strin
   return `${styleId}/${sanitizedQuality}/${sanitizedAspect}/${imageDigest}.jpg`;
 };
 
+async function handleWebhookRequest(req: Request, url: URL): Promise<Response> {
+  if (!webhookSecret) {
+    return createCorsResponse(JSON.stringify({ ok: false, error: 'webhook_not_configured' }), 500);
+  }
+
+  const token = url.searchParams.get('token');
+  if (token !== webhookSecret) {
+    return createCorsResponse(JSON.stringify({ ok: false, error: 'unauthorized' }), 401);
+  }
+
+  try {
+    const body = await req.json();
+    const status = body?.status as string | undefined ?? 'unknown';
+    const predictionId = body?.id as string | undefined;
+    const input = body?.input ?? {};
+    const requestId = input?.request_id as string | undefined;
+    const webhookLogger = createRequestLogger((requestId ?? predictionId ?? 'webhook').toString());
+    let output = body?.output as string | string[] | undefined;
+    if (Array.isArray(output)) {
+      output = output[0];
+    }
+    const errorMsg = body?.error as string | undefined;
+
+    const supabaseUrl = Deno.env.get('SUPABASE_URL');
+    const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+
+    if (!supabaseUrl || !supabaseServiceKey) {
+      return createCorsResponse(JSON.stringify({ ok: false, error: 'configuration_error' }), 500);
+    }
+
+    const supabase = createClient(supabaseUrl, supabaseServiceKey);
+    const cacheMetadataService = new CacheMetadataService(supabase);
+    const storageClient = new PreviewStorageClient(supabase, cacheBucket);
+
+    const identifierColumn = requestId ? 'request_id' : 'prediction_id';
+    const identifier = requestId ?? predictionId;
+
+    if (!identifier) {
+      return createCorsResponse(JSON.stringify({ ok: false, error: 'missing_request' }), 400);
+    }
+
+    const { data: statusRow, error: statusError } = await supabase
+      .from('previews_status')
+      .select('*')
+      .eq(identifierColumn, identifier)
+      .single();
+
+    if (statusError || !statusRow) {
+      return createCorsResponse(JSON.stringify({ ok: false, error: 'status_not_found' }), 404);
+    }
+
+    let previewUrl: string | null = statusRow.preview_url ?? null;
+    let cacheStatus: CacheStatus = 'miss';
+
+    if (status === 'succeeded' && output) {
+      try {
+        const imageDigest = statusRow.image_digest as string | null;
+        const styleId = statusRow.style_id as number | null;
+        const styleVersion = statusRow.style_version as string | null;
+        const aspectRatio = statusRow.aspect_ratio as string | null;
+        const quality = statusRow.quality as string | null;
+        const watermark = statusRow.watermark as boolean | null;
+        const cacheAllowed = (statusRow.cache_allowed as boolean | null) ?? true;
+
+        if (cacheAllowed && imageDigest && styleId && styleVersion && aspectRatio && quality && typeof watermark === 'boolean') {
+          const cacheKey = buildCacheKey({
+            imageDigest,
+            styleId,
+            styleVersion,
+            aspectRatio,
+            quality,
+            watermark
+          });
+
+          const storagePath = computeStoragePath(styleId, aspectRatio, quality, imageDigest);
+          const uploadResult = await storageClient.uploadFromUrl(output, storagePath);
+          previewUrl = uploadResult.publicUrl;
+
+          await cacheMetadataService.upsert({
+            cacheKey,
+            styleId,
+            styleVersion,
+            imageDigest,
+            aspectRatio,
+            quality,
+            watermark,
+            storagePath: uploadResult.storagePath,
+            previewUrl: uploadResult.publicUrl,
+            ttlExpiresAt: new Date(Date.now() + ttlMs).toISOString(),
+            sourceRequestId: statusRow.request_id as string
+          });
+
+          memoryCache.set(cacheKey, uploadResult.publicUrl, ttlMs);
+          cacheStatus = 'hit';
+        } else {
+          previewUrl = typeof output === 'string' ? output : null;
+          cacheStatus = 'bypass';
+        }
+      } catch (cacheError) {
+        webhookLogger.warn('Failed to persist cached preview from webhook', {
+          requestId: statusRow.request_id,
+          error: cacheError instanceof Error ? cacheError.message : String(cacheError)
+        });
+      }
+    }
+
+    const upsertPayload = {
+      request_id: statusRow.request_id,
+      prediction_id: predictionId ?? statusRow.prediction_id,
+      status,
+      preview_url: previewUrl,
+      error: errorMsg ?? null,
+      image_digest: statusRow.image_digest,
+      style_id: statusRow.style_id,
+      style_version: statusRow.style_version,
+      aspect_ratio: statusRow.aspect_ratio,
+      quality: statusRow.quality,
+      watermark: statusRow.watermark,
+      cache_allowed: statusRow.cache_allowed,
+      created_at: statusRow.created_at,
+      updated_at: new Date().toISOString()
+    };
+
+    await supabase.from('previews_status').upsert(upsertPayload, { onConflict: 'request_id' });
+
+    webhookLogger.info('Processed preview webhook callback', {
+      requestId: statusRow.request_id,
+      predictionId: predictionId ?? statusRow.prediction_id,
+      status,
+      cacheStatus,
+      hasPreview: Boolean(previewUrl)
+    });
+
+    return createCorsResponse(JSON.stringify({ ok: true, cacheStatus }), 200);
+  } catch (error) {
+    console.error('Webhook handling failed', error);
+    return createCorsResponse(JSON.stringify({ ok: false, error: 'webhook_error' }), 500);
+  }
+}
+
+async function handleStatusRequest(url: URL): Promise<Response> {
+  const requestId = url.searchParams.get('requestId');
+  if (!requestId) {
+    return createCorsResponse(JSON.stringify({ error: 'missing_requestId' }), 400);
+  }
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL');
+  const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+
+  if (!supabaseUrl || !supabaseServiceKey) {
+    return createCorsResponse(JSON.stringify({ error: 'configuration_error' }), 500);
+  }
+
+  const supabase = createClient(supabaseUrl, supabaseServiceKey);
+  const { data, error } = await supabase
+    .from('previews_status')
+    .select('request_id,status,preview_url,error,prediction_id,updated_at')
+    .eq('request_id', requestId)
+    .single();
+
+  if (error || !data) {
+    return createCorsResponse(JSON.stringify({ error: 'not_found' }), 404);
+  }
+
+  return createCorsResponse(JSON.stringify(data), 200);
+}
+
 serve(async (req) => {
+  const url = new URL(req.url);
+  const pathname = url.pathname;
+
   if (req.method === 'OPTIONS') {
     return handleCorsPreflightRequest();
+  }
+
+  if (req.method === 'POST' && pathname.endsWith('/webhook')) {
+    return handleWebhookRequest(req, url);
+  }
+
+  if (req.method === 'GET' && pathname.endsWith('/status')) {
+    return handleStatusRequest(url);
   }
 
   if (req.method !== 'POST') {
@@ -245,11 +426,10 @@ serve(async (req) => {
 
     const cacheAllowedForRequest = cacheEnabledGlobally && !cacheBypass;
     let cacheStatus: CacheStatus = cacheBypass ? 'bypass' : 'miss';
+    const imageDigest = await createImageDigest(normalizedImageUrl);
     let cacheKey: string | null = null;
-    let imageDigest: string | null = null;
 
     if (cacheAllowedForRequest) {
-      imageDigest = await createImageDigest(normalizedImageUrl);
       cacheKey = buildCacheKey({
         imageDigest,
         styleId: styleMetadata.styleId,
@@ -296,25 +476,10 @@ serve(async (req) => {
       }
     }
 
-    const replicateService = new ReplicateService(replicateApiToken, openaiApiKey);
-    const replicateStart = Date.now();
-    logger.info('Generating preview via Replicate', {
-      requestId,
-      cacheStatus,
-      cacheEnabled: cacheAllowedForRequest,
-      style,
-      aspectRatio,
-      quality
-    });
-
-    const result = await replicateService.generateImageToImage(normalizedImageUrl, stylePrompt, normalizedAspectRatio, normalizedQuality);
-    const replicateDurationMs = Date.now() - replicateStart;
-
-    if (result.ok && result.output) {
-      const rawOutput = Array.isArray(result.output) ? result.output[0] : result.output;
+    const persistGeneratedPreview = async (rawOutput: string): Promise<string> => {
       let finalPreviewUrl = rawOutput;
 
-      if (cacheAllowedForRequest && cacheKey && imageDigest && rawOutput) {
+      if (cacheAllowedForRequest && cacheKey) {
         try {
           const storagePath = computeStoragePath(styleMetadata.styleId, normalizedAspectRatio, normalizedQuality, imageDigest);
           const ttlExpiresAt = new Date(Date.now() + ttlMs).toISOString();
@@ -336,52 +501,172 @@ serve(async (req) => {
           });
 
           memoryCache.set(cacheKey, uploadResult.publicUrl, ttlMs);
-          cacheStatus = 'miss';
-          logger.info('Cached preview output', { cacheKey, storagePath: uploadResult.storagePath });
+          cacheStatus = 'hit';
         } catch (error) {
-          logger.warn('Failed to cache preview output', { error: error?.message ?? 'unknown', cacheKey });
+          logger.warn('Failed to cache preview output', { error: error instanceof Error ? error.message : String(error), cacheKey, requestId });
         }
+      } else if (!cacheAllowedForRequest) {
+        cacheStatus = cacheBypass ? 'bypass' : cacheStatus;
       }
 
-      const duration = Date.now() - startTime;
-      console.log('[preview-metrics]', {
+      return finalPreviewUrl;
+    };
+
+    const isAuthenticated = Boolean(body?.isAuthenticated);
+
+    if (asyncEnabled && (!webhookBaseUrl || !webhookSecret)) {
+      logger.warn('Async preview enabled but webhook configuration is incomplete. Falling back to synchronous mode.', {
+        hasBaseUrl: Boolean(webhookBaseUrl),
+        hasSecret: Boolean(webhookSecret)
+      });
+    }
+
+    if (asyncEnabled && webhookBaseUrl && webhookSecret) {
+      const webhookUrl = `${webhookBaseUrl.replace(/\/$/, '')}/functions/v1/generate-style-preview/webhook?token=${webhookSecret}`;
+      const createBody = {
+        input: {
+          prompt: stylePrompt,
+          input_images: [normalizedImageUrl],
+          openai_api_key: openaiApiKey,
+          aspect_ratio: normalizedAspectRatio,
+          quality: normalizedQuality,
+          request_id: requestId
+        },
+        webhook: webhookUrl,
+        webhook_events_filter: ['completed', 'failed', 'canceled']
+      } as const;
+
+      const asyncResp = await fetch('https://api.replicate.com/v1/models/openai/gpt-image-1/predictions', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${replicateApiToken}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(createBody)
+      });
+
+      if (!asyncResp.ok) {
+        const errTxt = await asyncResp.text();
+        logger.error('Replicate async create failed', { requestId, status: asyncResp.status, errTxt });
+        return createCorsResponse(
+          JSON.stringify(createErrorResponse('generation_failed', `GPT-Image-1 API request failed: ${asyncResp.status} - ${errTxt}`, requestId)),
+          503
+        );
+      }
+
+      const asyncData = await asyncResp.json();
+
+      if (asyncData?.status === 'succeeded' && asyncData?.output) {
+        const immediateOutput = Array.isArray(asyncData.output) ? asyncData.output[0] : asyncData.output;
+        const finalPreviewUrl = await persistGeneratedPreview(immediateOutput);
+        const duration = Date.now() - startTime;
+
+        await supabase.from('previews_status').upsert({
+          request_id: requestId,
+          prediction_id: asyncData?.id ?? null,
+          status: 'succeeded',
+          preview_url: finalPreviewUrl,
+          error: null,
+          image_digest: imageDigest,
+          style_id: styleMetadata.styleId,
+          style_version: styleMetadata.styleVersion,
+          aspect_ratio: normalizedAspectRatio,
+          quality: normalizedQuality,
+          watermark,
+          cache_allowed: cacheAllowedForRequest,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString()
+        }, { onConflict: 'request_id' });
+
+        logger.info('Replicate returned immediate result', { requestId, cacheStatus });
+        return createCorsResponse(
+          JSON.stringify(createSuccessResponse(finalPreviewUrl, requestId, duration, cacheStatus)),
+          200
+        );
+      }
+
+      await supabase.from('previews_status').upsert({
+        request_id: requestId,
+        prediction_id: asyncData?.id ?? null,
+        status: asyncData?.status ?? 'processing',
+        preview_url: null,
+        error: null,
+        image_digest: imageDigest,
+        style_id: styleMetadata.styleId,
+        style_version: styleMetadata.styleVersion,
+        aspect_ratio: normalizedAspectRatio,
+        quality: normalizedQuality,
+        watermark,
+        cache_allowed: cacheAllowedForRequest,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString()
+      }, { onConflict: 'request_id' });
+
+      logger.info('Queued preview generation via webhook', {
         requestId,
-        style,
-        action: 'replicate_success',
-        replicateDurationMs,
-        totalDurationMs: duration,
-        promptCacheHit: promptCacheWasHit,
-        outputCacheStatus: cacheStatus
+        status: asyncData?.status ?? 'processing',
+        cacheAllowedForRequest
       });
 
       return createCorsResponse(
-        JSON.stringify(createSuccessResponse(finalPreviewUrl, requestId, duration, cacheStatus))
+        JSON.stringify({ requestId, status: asyncData?.status ?? 'processing', isAuthenticated }),
+        202
+      );
+    }
+
+    const replicateService = new ReplicateService(replicateApiToken, openaiApiKey);
+    const replicateStart = Date.now();
+
+    logger.info('Generating preview via Replicate', {
+      requestId,
+      cacheStatus,
+      cacheEnabled: cacheAllowedForRequest,
+      style,
+      aspectRatio,
+      quality
+    });
+
+    const result = await replicateService.generateImageToImage(normalizedImageUrl, stylePrompt, normalizedAspectRatio, normalizedQuality);
+    const replicateDurationMs = Date.now() - replicateStart;
+
+    if (result.ok && result.output) {
+      const rawOutput = Array.isArray(result.output) ? result.output[0] : result.output;
+      const finalPreviewUrl = await persistGeneratedPreview(rawOutput);
+      const duration = Date.now() - startTime;
+
+      if (asyncEnabled && webhookBaseUrl && webhookSecret) {
+        await supabase.from('previews_status').upsert({
+          request_id: requestId,
+          prediction_id: null,
+          status: 'succeeded',
+          preview_url: finalPreviewUrl,
+          error: null,
+          image_digest: imageDigest,
+          style_id: styleMetadata.styleId,
+          style_version: styleMetadata.styleVersion,
+          aspect_ratio: normalizedAspectRatio,
+          quality: normalizedQuality,
+          watermark,
+          cache_allowed: cacheAllowedForRequest,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString()
+        }, { onConflict: 'request_id' });
+      }
+
+      logger.info('Replicate generation success', { requestId, replicateDurationMs, cacheStatus });
+      return createCorsResponse(
+        JSON.stringify(createSuccessResponse(finalPreviewUrl, requestId, duration, cacheStatus)),
+        200
       );
     }
 
     logger.error('Replicate generation failed', { error: result.error, requestId });
-    console.error('[preview-metrics]', {
-      requestId,
-      style,
-      action: 'replicate_failure',
-      replicateDurationMs,
-      promptCacheHit: promptCacheWasHit,
-      outputCacheStatus: cacheStatus,
-      error: result.error || 'unknown_error'
-    });
     return createCorsResponse(
       JSON.stringify(createErrorResponse('generation_failed', result.error || 'AI service is temporarily unavailable. Please try again.', requestId)),
       503
     );
   } catch (error) {
-    const duration = Date.now() - startTime;
     logger.error('Unhandled error in preview generation', { error: error?.message ?? 'unknown', requestId });
-    console.error('[preview-metrics]', {
-      requestId,
-      action: 'replicate_exception',
-      totalDurationMs: duration,
-      message: error instanceof Error ? error.message : String(error)
-    });
     return createCorsResponse(
       JSON.stringify(createErrorResponse('internal_error', 'Internal server error. Please try again.', requestId)),
       500

--- a/supabase/migrations/20250731123000_preview_status.sql
+++ b/supabase/migrations/20250731123000_preview_status.sql
@@ -1,0 +1,60 @@
+-- Store asynchronous preview generation status while webhooks complete
+
+create table if not exists public.previews_status (
+  request_id text primary key,
+  prediction_id text,
+  status text not null,
+  preview_url text,
+  error text,
+  image_digest text,
+  style_id integer,
+  style_version text,
+  aspect_ratio text,
+  quality text,
+  watermark boolean,
+  cache_allowed boolean default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists previews_status_prediction_idx
+  on public.previews_status (prediction_id);
+
+create index if not exists previews_status_status_idx
+  on public.previews_status (status);
+
+alter table public.previews_status enable row level security;
+
+create policy if not exists previews_status_service_role_policy
+  on public.previews_status
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+create or replace function public.touch_previews_status()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  new.updated_at := now();
+  return new;
+end;
+$$;
+
+grant execute on function public.touch_previews_status() to service_role;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_trigger
+    where tgname = 'trg_touch_previews_status'
+  ) then
+    create trigger trg_touch_previews_status
+      before update on public.previews_status
+      for each row
+      execute function public.touch_previews_status();
+  end if;
+end;
+$$;


### PR DESCRIPTION
## Summary\n- introduce hybrid preview caching (memory + Supabase storage) to keep Wondertone's premium canvas experience responsive\n- add optional webhook-driven async flow so configurator gating stays intact while previews process\n- surface cache-aware hooks and migrations to preserve throughput guardrails and future observability\n\n## Testing\n- npm run build\n- npm run build:analyze\n- npm run lint *(fails on existing eslint debt present on origin/main)*\n- npm run deps:check *(flags autoprefixer/postcss unused + lint-staged/https:: missing — matches current baseline)*],